### PR TITLE
added func to trim each line in a string

### DIFF
--- a/pkg/strext/examples_test.go
+++ b/pkg/strext/examples_test.go
@@ -14,12 +14,43 @@ func ExampleTrim() {
 		"",
 		"Four",
 	}
-	var expectedValues = []string{"one", "two", "Three", "Four"}
+	var expectedValues = []string{"", "one", "two", "Three", "", "Four"}
+	var expectedTrimmedValues = []string{"one", "two", "Three", "Four"}
 
-	newValues := Trim(values)
+	newValues := TrimArray(values, true)
 
+	if reflect.DeepEqual(newValues, expectedTrimmedValues) {
+		fmt.Println("String array trimmed and empties removed!")
+	}
+
+	newValues = TrimArray(values, false)
 	if reflect.DeepEqual(newValues, expectedValues) {
 		fmt.Println("String array trimmed!")
 	}
-	// Output: String array trimmed!
+
+	// Output: String array trimmed and empties removed!
+	// String array trimmed!
+}
+
+func ExampleTrimLines() {
+	var value = `
+This is line 1.		
+	This is line 2.
+
+
+This is line 5.
+	`
+	var expectedValue = `
+This is line 1.
+This is line 2.
+
+
+This is line 5.
+`
+	trimmedLines := TrimLines(value)
+
+	if trimmedLines == expectedValue {
+		fmt.Printf("Lines trimmed!")
+	}
+	// Output: Lines trimmed!
 }

--- a/pkg/strext/funcs.go
+++ b/pkg/strext/funcs.go
@@ -2,14 +2,34 @@ package strext
 
 import "strings"
 
-// Trim - trims whitespace from the array of strings.  Any strings that are empty after
-// the trimming are omitted from the output
-func Trim(values []string) (result []string) {
-	for _, value := range values {
-		if trimmedValue := strings.TrimSpace(value); trimmedValue != "" {
-			result = append(result, trimmedValue)
+// TrimArray - trims whitespace from the array of strings.
+//
+// If removeEmpty=true, then any trimmed values are not included in the result array.
+//
+// If removeEmpty=false, then empty values may be included in the result array.
+func TrimArray(values []string, removeEmpty bool) []string {
+	if removeEmpty {
+		result := []string{}
+
+		for _, value := range values {
+			if trimmedValue := strings.TrimSpace(value); trimmedValue != "" {
+				result = append(result, trimmedValue)
+			}
 		}
+
+		return result
 	}
 
+	result := make([]string, 0, len(values))
+
+	for _, value := range values {
+		result = append(result, strings.TrimSpace(value))
+	}
 	return result
+}
+
+// TrimLines - for each line in the string, it trims whitespace. The new
+// "trimmed" string is returned. Empty lines remain in the resulting string.
+func TrimLines(value string) string {
+	return strings.Join(TrimArray(strings.Split(value, "\n"), false), "\n")
 }


### PR DESCRIPTION
- Renamed `Trim([]string) []string` to `TrimArray([]string, bool) []string` and added a flag to remove blank elements from array
- Add `TrimLines(value string) string` to trim each line of a multiline string